### PR TITLE
Lors du lancement de la procédure psLrecCree, le  paramètre @code_cat

### DIFF
--- a/.settings/.gitignore
+++ b/.settings/.gitignore
@@ -1,0 +1,11 @@
+/.jsdtscope
+/org.eclipse.core.resources.prefs
+/org.eclipse.jdt.core.prefs
+/org.eclipse.jpt.core.prefs
+/org.eclipse.m2e.core.prefs
+/org.eclipse.wst.common.component
+/org.eclipse.wst.common.project.facet.core.prefs.xml
+/org.eclipse.wst.common.project.facet.core.xml
+/org.eclipse.wst.jsdt.ui.superType.container
+/org.eclipse.wst.jsdt.ui.superType.name
+/org.eclipse.wst.validation.prefs

--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@ Contient les interfaces utilisateur et l'accés à la base de données CPWin
   <profile>
   <id>GBCP</id>
    <activation>
-  <activeByDefault>true</activeByDefault>
+  <activeByDefault>false</activeByDefault>
   </activation>
   <properties>
   <app.name>${project.artifactId}</app.name>
@@ -225,7 +225,7 @@ Contient les interfaces utilisateur et l'accés à la base de données CPWin
   <profile>
   <id>GTS</id>
    <activation>
-  <activeByDefault>false</activeByDefault>
+  <activeByDefault>true</activeByDefault>
   </activation>
   <properties>
   <app.name>gts</app.name>

--- a/src/main/java/fr/symphonie/tools/gts/core/ps/PsLrecCree.java
+++ b/src/main/java/fr/symphonie/tools/gts/core/ps/PsLrecCree.java
@@ -76,7 +76,7 @@ public class PsLrecCree extends GenericGtsPs {
 		inputs.put(document, null);
 		inputs.put(tiers_orig, liqRec.getTiersOrigine());
 		inputs.put(debiteur, liqRec.getDebiteur());
-		inputs.put(code_cat, "1");
+		inputs.put(code_cat,liqRec.getTiers().isRegisseur()?"3": "1");
 		inputs.put(no_inv, null);
 		inputs.put(piece_externe, 0);
 		inputs.put(type_piece_externe, null);


### PR DESCRIPTION
doit être passer à "3" au lieu de "1" si le @debiteur est typé
gts_client.est_regisseur = 1